### PR TITLE
Update tm-example-non-vpc to fix a typo

### DIFF
--- a/doc_source/tm-example-non-vpc.md
+++ b/doc_source/tm-example-non-vpc.md
@@ -78,7 +78,7 @@ Create the following inbound rules:
 | Protocol | All | 
 | Source port range |  | 
 | Destination port range |  | 
-| Source CIDR block | 0\.0\.0\.0\.0/0 | 
+| Source CIDR block | 0\.0\.0\.0/0 | 
 | Destination CIDR block | 0\.0\.0\.0/0 | 
 | Description | Accept all inbound traffic | 
 


### PR DESCRIPTION
Fixed inbound rule CIDR from `0.0.0.0.0` to `0.0.0.0`.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
